### PR TITLE
fix: remove oldest messages when reaching overflow limit

### DIFF
--- a/src/web/js/chat.js
+++ b/src/web/js/chat.js
@@ -20,7 +20,7 @@ const chat = createApp({
 			}, 1200);
 		};
 		const removeMessages = (count) => {
-			messages.value = messages.value.slice(count);
+			messages.value = messages.value.slice(0, -count);
 		};
 		const removeItem = (id) => {
 			messages.value = messages.value.filter((f) => f.id !== id);


### PR DESCRIPTION
Fixes an issue where the newest messages were being removed when the chat box overflows. 

Newest messages are added to the beginning of the array. 

Old messages should be sliced from the end of the array, not the start

:) 